### PR TITLE
Return a "complete" transformation key.

### DIFF
--- a/FaceCropper-library/src/main/java/cat/lafosca/facecropper/FaceCropper.java
+++ b/FaceCropper-library/src/main/java/cat/lafosca/facecropper/FaceCropper.java
@@ -77,6 +77,10 @@ public class FaceCropper {
         mSizeMode = SizeMode.FaceMarginPx;
     }
 
+    public SizeMode getSizeMode() {
+        return mSizeMode;
+    }
+
     public float getEyeDistanceFactorMargin() {
         return mEyeDistanceFactorMargin;
     }


### PR DESCRIPTION
Using a transformation key with the current FaceCropper config, allows us
to properlly use Picasso's cache.

To support this, I had to add a getSizeMode() method to FaceCropper.
The enum was already public, so a getter makes sense.

Also asked for a RGB_565 bitmap in Picasso's RequestCreator, so we don't
have to convert it later, causing extra GC.
